### PR TITLE
feat!: stricter decorator typing 

### DIFF
--- a/test/pg-boss.e2e-spec.ts
+++ b/test/pg-boss.e2e-spec.ts
@@ -1,11 +1,11 @@
-import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication, Injectable } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { Job } from "pg-boss";
 import {
   PostgreSqlContainer,
   StartedPostgreSqlContainer,
 } from "testcontainers";
-import { createJob, JobService, PGBossModule } from "../src";
-import { Job } from "pg-boss";
+import { JobService, PGBossModule, createJob } from "../src";
 
 interface FoobarJobData {
   foo: string;


### PR DESCRIPTION
The `@FooJob.Handle()` decorator now verifies that the decorated method accepts the right arguments.