### PR TITLE
feat: error handler

### DIFF
--- a/src/interfaces/pg-boss-options.interface.ts
+++ b/src/interfaces/pg-boss-options.interface.ts
@@ -25,4 +25,9 @@ export type PGBossModuleOptions = {
    * If `true`, will show verbose error messages on each connection retry.
    */
   verboseRetryLog?: boolean;
+  /**
+   * If set, will add a handler to the 'error' event
+   * @param error error that was thrown
+   */
+  onErrorHandler?: (error: Error) => void;
 } & ConstructorOptions;

--- a/src/pg-boss.module.ts
+++ b/src/pg-boss.module.ts
@@ -96,6 +96,9 @@ export class PGBossModule
         ),
       ),
     );
+    if (options.onErrorHandler) {
+      pgBoss.on('error', options.onErrorHandler);
+    }
 
     return pgBoss;
   }


### PR DESCRIPTION
This update allows to set an error handler: [https://github.com/timgit/pg-boss/blob/9.0.0/docs/readme.md#error](https://github.com/timgit/pg-boss/blob/9.0.0/docs/readme.md#error)